### PR TITLE
Implement lessons, code exec, and AI chat

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import PracticePage from './pages/PracticePage';
 import ProfilePage from './pages/ProfilePage';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
+import ChatPage from './pages/ChatPage';
 
 function App() {
   const loadUser = useAuthStore((state) => state.loadUser);
@@ -36,6 +37,7 @@ function App() {
           <Route index element={<HomePage />} />
           <Route path="learn" element={<LearnPage />} />
           <Route path="practice" element={<PracticePage />} />
+          <Route path="chat" element={<ChatPage />} />
           <Route path="profile" element={<ProfilePage />} />
         </Route>
         <Route path="/login" element={<LoginPage />} />

--- a/client/src/components/CodeEditor/index.tsx
+++ b/client/src/components/CodeEditor/index.tsx
@@ -1,5 +1,5 @@
-import { useRef, useEffect } from 'react';
-import Editor, { OnMount, Monaco } from '@monaco-editor/react';
+import { useRef } from 'react';
+import Editor, { OnMount } from '@monaco-editor/react';
 import { motion } from 'framer-motion';
 import { useExplainCode, useDebugCode } from '@/hooks/useAI';
 

--- a/client/src/pages/ChatPage.tsx
+++ b/client/src/pages/ChatPage.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from 'react'
+
+interface ChatMessage {
+  sender: 'user' | 'ai'
+  text: string
+}
+
+const ChatPage = () => {
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [input, setInput] = useState('')
+  const wsRef = useRef<WebSocket | null>(null)
+
+  useEffect(() => {
+    const wsUrl = (import.meta.env.VITE_API_URL || 'http://localhost:3001/api')
+      .replace('http', 'ws')
+      .replace(/\/api$/, '') + '/ws/chat'
+    const ws = new WebSocket(wsUrl)
+    ws.onmessage = (event) => {
+      setMessages((m) => [...m, { sender: 'ai', text: event.data }])
+    }
+    wsRef.current = ws
+    return () => ws.close()
+  }, [])
+
+  const sendMessage = () => {
+    if (input.trim() && wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(input)
+      setMessages((m) => [...m, { sender: 'user', text: input }])
+      setInput('')
+    }
+  }
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">AI Chat</h1>
+      <div className="h-96 overflow-y-auto glass-morphism p-4 space-y-2 mb-4">
+        {messages.map((msg, idx) => (
+          <div key={idx} className={msg.sender === 'user' ? 'text-right' : 'text-left'}>
+            <span className="block text-xs text-gray-400 mb-1">{msg.sender === 'user' ? 'You' : 'AI'}</span>
+            <span className="inline-block bg-gray-800/50 px-3 py-2 rounded-lg max-w-xs">
+              {msg.text}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input
+          className="flex-1 glass-morphism p-2 rounded"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
+        />
+        <button className="bg-blue-500 px-4 rounded" onClick={sendMessage}>Send</button>
+      </div>
+    </div>
+  )
+}
+
+export default ChatPage

--- a/client/src/pages/LearnPage.tsx
+++ b/client/src/pages/LearnPage.tsx
@@ -1,5 +1,7 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
+import lessonService from '../services/lessonService'
+import { Lesson } from '../types/lesson'
 
 const LearnPage = () => {
   const [selectedCategory, setSelectedCategory] = useState('all')
@@ -11,48 +13,13 @@ const LearnPage = () => {
     { id: 'advanced', label: 'Advanced' },
   ]
 
-  const courses = [
-    {
-      id: 1,
-      title: 'Introduction to Programming',
-      description: 'Learn the fundamentals of programming with JavaScript',
-      level: 'beginner',
-      duration: '4 weeks',
-      lessons: 20,
-      icon: '🚀',
-    },
-    {
-      id: 2,
-      title: 'Web Development Basics',
-      description: 'Build your first website with HTML, CSS, and JavaScript',
-      level: 'beginner',
-      duration: '6 weeks',
-      lessons: 30,
-      icon: '🌐',
-    },
-    {
-      id: 3,
-      title: 'Python for Data Science',
-      description: 'Master Python for data analysis and visualization',
-      level: 'intermediate',
-      duration: '8 weeks',
-      lessons: 40,
-      icon: '📊',
-    },
-    {
-      id: 4,
-      title: 'React Development',
-      description: 'Build modern web applications with React',
-      level: 'intermediate',
-      duration: '6 weeks',
-      lessons: 35,
-      icon: '⚛️',
-    },
-  ]
+  const [courses, setCourses] = useState<Lesson[]>([])
 
-  const filteredCourses = selectedCategory === 'all' 
-    ? courses 
-    : courses.filter(course => course.level === selectedCategory)
+  useEffect(() => {
+    lessonService.getAllLessons().then(setCourses).catch(console.error)
+  }, [])
+
+  const filteredCourses = courses
 
   return (
     <div>
@@ -91,15 +58,10 @@ const LearnPage = () => {
             transition={{ duration: 0.3, delay: index * 0.1 }}
             whileHover={{ y: -5 }}
           >
-            <div className="text-4xl mb-4">{course.icon}</div>
             <h3 className="text-xl font-semibold mb-2">{course.title}</h3>
             <p className="text-gray-400 mb-4">{course.description}</p>
-            
-            <div className="flex items-center justify-between text-sm text-gray-500 mb-4">
-              <span className="capitalize">{course.level}</span>
-              <span>{course.duration}</span>
-              <span>{course.lessons} lessons</span>
-            </div>
+
+            <div className="text-sm text-gray-500 mb-4">Created at {new Date(course.createdAt).toLocaleDateString()}</div>
 
             <button className="w-full py-2 bg-blue-500 hover:bg-blue-600 rounded-lg transition-colors">
               Start Learning

--- a/client/src/pages/PracticePage.tsx
+++ b/client/src/pages/PracticePage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import CodeEditor from '@/components/CodeEditor'
 import { motion } from 'framer-motion'
+import execService from '../services/execService'
 
 const PracticePage = () => {
   const [code, setCode] = useState(`function fibonacci(n) {
@@ -11,13 +12,16 @@ const PracticePage = () => {
   const [output, setOutput] = useState('');
   const [error, setError] = useState('');
 
-  const handleRunCode = () => {
-    // Simulate running code (in production, this would call a code execution API)
+  const handleRunCode = async () => {
     try {
       setError('');
-      // Simple simulation - in reality, this would be sandboxed execution
-      const result = `Code execution simulation:\nYour function has been defined. Try calling fibonacci(5) to test it!`;
-      setOutput(result);
+      const res = await execService.runCode('javascript', code);
+      if (res.error) {
+        setError(res.error);
+        setOutput('');
+      } else {
+        setOutput(res.output);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
       setOutput('');

--- a/client/src/services/execService.ts
+++ b/client/src/services/execService.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001/api';
+
+class ExecService {
+  private axiosInstance;
+  constructor() {
+    this.axiosInstance = axios.create({ baseURL: API_BASE_URL });
+  }
+
+  async runCode(language: string, code: string): Promise<{ output: string; error?: string }> {
+    const res = await this.axiosInstance.post('/exec', { language, code });
+    return res.data;
+  }
+}
+
+export default new ExecService();

--- a/client/src/services/lessonService.ts
+++ b/client/src/services/lessonService.ts
@@ -1,0 +1,28 @@
+import axios from 'axios';
+import { Lesson } from '../types/lesson';
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001/api';
+
+class LessonService {
+  private axiosInstance;
+  constructor() {
+    this.axiosInstance = axios.create({ baseURL: API_BASE_URL });
+  }
+
+  async getAllLessons(): Promise<Lesson[]> {
+    const res = await this.axiosInstance.get('/lessons');
+    return res.data.lessons;
+  }
+
+  async getLesson(id: number): Promise<Lesson> {
+    const res = await this.axiosInstance.get(`/lessons/${id}`);
+    return res.data;
+  }
+
+  async getExercises(id: number): Promise<any[]> {
+    const res = await this.axiosInstance.get(`/lessons/${id}/exercises`);
+    return res.data.exercises;
+  }
+}
+
+export default new LessonService();

--- a/client/src/store/authStore.ts
+++ b/client/src/store/authStore.ts
@@ -27,7 +27,7 @@ export const useAuthStore = create<AuthStore>()(
       login: async (credentials: LoginCredentials) => {
         set({ isLoading: true });
         try {
-          const { user, token } = await authService.login(credentials);
+          const { token } = await authService.login(credentials);
           
           // Get full user data with progress
           const userWithProgress = await authService.getCurrentUser();

--- a/client/src/types/lesson.ts
+++ b/client/src/types/lesson.ts
@@ -1,0 +1,6 @@
+export interface Lesson {
+  id: number;
+  title: string;
+  description?: string | null;
+  createdAt: string;
+}

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -2673,6 +2673,23 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
     },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -12790,6 +12807,19 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -13387,6 +13417,27 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -13542,7 +13593,9 @@
         "jsonwebtoken": "^9.0.2",
         "openai": "^5.8.2",
         "pg": "^8.11.3",
+        "uuid": "^9.0.1",
         "winston": "^3.11.0",
+        "ws": "^8.13.0",
         "zod": "^3.25.74"
       },
       "devDependencies": {
@@ -13555,6 +13608,8 @@
         "@types/jsonwebtoken": "^9.0.5",
         "@types/node": "^20.10.5",
         "@types/pg": "^8.15.4",
+        "@types/uuid": "^10.0.0",
+        "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^6.15.0",
         "@typescript-eslint/parser": "^6.15.0",
         "eslint": "^8.56.0",

--- a/server/package.json
+++ b/server/package.json
@@ -33,7 +33,9 @@
     "jsonwebtoken": "^9.0.2",
     "openai": "^5.8.2",
     "pg": "^8.11.3",
+    "uuid": "^9.0.1",
     "winston": "^3.11.0",
+    "ws": "^8.13.0",
     "zod": "^3.25.74"
   },
   "devDependencies": {
@@ -46,6 +48,8 @@
     "@types/jsonwebtoken": "^9.0.5",
     "@types/node": "^20.10.5",
     "@types/pg": "^8.15.4",
+    "@types/uuid": "^10.0.0",
+    "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "@typescript-eslint/parser": "^6.15.0",
     "eslint": "^8.56.0",

--- a/server/src/api/exec/index.ts
+++ b/server/src/api/exec/index.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import codeExecutionService from '../../services/codeExecutionService';
+
+const router = Router();
+
+router.post('/', async (req, res, next) => {
+  try {
+    const { language, code } = req.body;
+    const result = await codeExecutionService.runCode(language, code);
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -3,6 +3,7 @@ import aiRoutes from './ai';
 import authRoutes from './auth';
 import lessonsRoutes from './lessons';
 import progressRoutes from './progress';
+import execRoutes from './exec';
 
 const router = Router();
 
@@ -16,6 +17,7 @@ router.get('/', (req, res) => {
       auth: '/api/auth',
       lessons: '/api/lessons',
       progress: '/api/progress',
+      exec: '/api/exec',
     },
   });
 });
@@ -25,5 +27,6 @@ router.use('/ai', aiRoutes);
 router.use('/auth', authRoutes);
 router.use('/lessons', lessonsRoutes);
 router.use('/progress', progressRoutes);
+router.use('/exec', execRoutes);
 
 export default router;

--- a/server/src/api/lessons/index.ts
+++ b/server/src/api/lessons/index.ts
@@ -1,49 +1,46 @@
 import { Router } from 'express';
+import lessonService from '../../services/lessonService';
 
 const router = Router();
 
 // Get all lessons
-router.get('/', async (req, res, next) => {
+router.get('/', async (_req, res, next): Promise<void> => {
   try {
-    // TODO: Implement get all lessons
-    res.json({
-      lessons: [],
-      total: 0,
-    });
+    const lessons = await lessonService.getAllLessons();
+    res.json({ lessons, total: lessons.length });
   } catch (error) {
     next(error);
   }
 });
 
 // Get lesson by ID
-router.get('/:id', async (req, res, next) => {
+router.get('/:id', async (req, res, next): Promise<void> => {
   try {
     const { id } = req.params;
-    // TODO: Implement get lesson by ID
-    res.json({
-      message: `Get lesson ${id} - to be implemented`,
-    });
+    const lesson = await lessonService.getLessonById(Number(id));
+    if (!lesson) {
+      res.status(404).json({ error: 'Lesson not found' });
+      return;
+    }
+    res.json(lesson);
   } catch (error) {
     next(error);
   }
 });
 
 // Get exercises for a lesson
-router.get('/:id/exercises', async (req, res, next) => {
+router.get('/:id/exercises', async (req, res, next): Promise<void> => {
   try {
     const { id } = req.params;
-    // TODO: Implement get exercises
-    res.json({
-      exercises: [],
-      lessonId: id,
-    });
+    const exercises = await lessonService.getExercisesForLesson(Number(id));
+    res.json({ exercises, lessonId: id });
   } catch (error) {
     next(error);
   }
 });
 
 // Submit exercise solution
-router.post('/:lessonId/exercises/:exerciseId/submit', async (req, res, next) => {
+router.post('/:lessonId/exercises/:exerciseId/submit', async (req, res, next): Promise<void> => {
   try {
     const { lessonId, exerciseId } = req.params;
     const { code } = req.body;

--- a/server/src/db/migrate.ts
+++ b/server/src/db/migrate.ts
@@ -4,31 +4,65 @@ import dotenv from 'dotenv';
 import database from './connection';
 import { logger } from '../utils/logger';
 
+interface Migration {
+  name: string;
+  sql: string;
+}
+
 dotenv.config();
 
 async function migrate() {
   try {
     logger.info('Starting database migration...');
-    
+
     // Test database connection
     const connected = await database.testConnection();
     if (!connected) {
       throw new Error('Cannot connect to database');
     }
 
-    // Read and execute schema.sql
+    await database.query(
+      `CREATE TABLE IF NOT EXISTS migrations (
+        id SERIAL PRIMARY KEY,
+        name TEXT UNIQUE NOT NULL,
+        run_on TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      )`
+    );
+
+    const migrations: Migration[] = [];
+
+    // Include main schema.sql as initial migration
     const schemaPath = path.join(__dirname, 'schema.sql');
-    const schemaSql = fs.readFileSync(schemaPath, 'utf8');
-    
-    // Split by semicolon and execute each statement
-    const statements = schemaSql.split(';').filter(stmt => stmt.trim().length > 0);
-    
-    for (const statement of statements) {
-      if (statement.trim()) {
-        await database.query(statement);
+    if (fs.existsSync(schemaPath)) {
+      const schemaSql = fs.readFileSync(schemaPath, 'utf8');
+      migrations.push({ name: 'schema.sql', sql: schemaSql });
+    }
+
+    const migrationsDir = path.join(__dirname, 'migrations');
+    if (fs.existsSync(migrationsDir)) {
+      const files = fs.readdirSync(migrationsDir)
+        .filter((f) => f.endsWith('.sql'))
+        .sort();
+      for (const file of files) {
+        const sql = fs.readFileSync(path.join(migrationsDir, file), 'utf8');
+        migrations.push({ name: file, sql });
       }
     }
-    
+
+    for (const migration of migrations) {
+      const exists = await database.query('SELECT 1 FROM migrations WHERE name = $1', [migration.name]);
+      if (exists.rows.length > 0) {
+        continue;
+      }
+
+      logger.info(`Applying migration: ${migration.name}`);
+      const statements = migration.sql.split(';').filter((s) => s.trim().length > 0);
+      for (const statement of statements) {
+        await database.query(statement);
+      }
+      await database.query('INSERT INTO migrations(name) VALUES($1)', [migration.name]);
+    }
+
     logger.info('Database migration completed successfully');
   } catch (error) {
     logger.error('Database migration failed:', error);

--- a/server/src/db/migrations/002_create_lessons_tables.sql
+++ b/server/src/db/migrations/002_create_lessons_tables.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS lessons (
+  id SERIAL PRIMARY KEY,
+  title VARCHAR(255) NOT NULL,
+  description TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS lesson_exercises (
+  lesson_id INTEGER REFERENCES lessons(id) ON DELETE CASCADE,
+  exercise_id INTEGER REFERENCES exercises(id) ON DELETE CASCADE,
+  order_index INTEGER NOT NULL,
+  PRIMARY KEY (lesson_id, exercise_id)
+);
+
+INSERT INTO lessons (title, description) VALUES
+  ('Intro to JavaScript', 'Basics of JavaScript language');
+
+INSERT INTO lesson_exercises (lesson_id, exercise_id, order_index)
+SELECT 1, id, ROW_NUMBER() OVER () FROM exercises LIMIT 1;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,15 +3,18 @@ import cors from 'cors';
 import helmet from 'helmet';
 import compression from 'compression';
 import dotenv from 'dotenv';
+import { createServer } from 'http';
 import { errorHandler } from './middleware/errorHandler';
 import { logger } from './utils/logger';
 import database from './db/connection';
 import apiRoutes from './api';
+import { setupChatServer } from './websocket/chatServer';
 
 dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3001;
+const httpServer = createServer(app);
 
 // Middleware
 app.use(helmet());
@@ -39,8 +42,11 @@ app.use('/api', apiRoutes);
 app.use(errorHandler);
 
 // Start server
-app.listen(PORT, async () => {
+httpServer.listen(PORT, async () => {
   logger.info(`Server running on port ${PORT}`);
+
+  // Setup WebSocket chat
+  setupChatServer(httpServer);
   
   // Test database connection
   const dbConnected = await database.testConnection();

--- a/server/src/services/codeExecutionService.ts
+++ b/server/src/services/codeExecutionService.ts
@@ -1,0 +1,52 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+import vm from 'vm';
+
+const execAsync = promisify(exec);
+
+class CodeExecutionService {
+  async runCode(language: string, code: string): Promise<{ output: string; error?: string }> {
+    if (!code) {
+      throw new Error('No code provided');
+    }
+
+    switch (language) {
+      case 'javascript':
+        return this.runJavascript(code);
+      case 'python':
+        return this.runPython(code);
+      default:
+        throw new Error('Unsupported language');
+    }
+  }
+
+  private async runJavascript(code: string) {
+    try {
+      const script = new vm.Script(code);
+      const result = script.runInNewContext({}, { timeout: 3000 });
+      return { output: result !== undefined ? String(result) : '' };
+    } catch (err: any) {
+      return { output: '', error: err.message };
+    }
+  }
+
+  private async runPython(code: string) {
+    const filename = path.join(os.tmpdir(), `exec-${uuidv4()}.py`);
+    await fs.writeFile(filename, code);
+    try {
+      const { stdout, stderr } = await execAsync(`python3 ${filename}`, { timeout: 5000 });
+      await fs.unlink(filename);
+      if (stderr) return { output: '', error: stderr.trim() };
+      return { output: stdout.trim() };
+    } catch (err: any) {
+      await fs.unlink(filename);
+      return { output: '', error: err.stderr || err.message };
+    }
+  }
+}
+
+export default new CodeExecutionService();

--- a/server/src/services/lessonService.ts
+++ b/server/src/services/lessonService.ts
@@ -1,0 +1,38 @@
+import database from '../db/connection';
+import { logger } from '../utils/logger';
+import { Lesson } from '../types/lesson';
+
+class LessonService {
+  async getAllLessons(): Promise<Lesson[]> {
+    const result = await database.query('SELECT id, title, description, created_at FROM lessons ORDER BY id');
+    return result.rows.map(this.mapRow);
+  }
+
+  async getLessonById(id: number): Promise<Lesson | null> {
+    const result = await database.query('SELECT id, title, description, created_at FROM lessons WHERE id=$1', [id]);
+    if (result.rows.length === 0) return null;
+    return this.mapRow(result.rows[0]);
+  }
+
+  async getExercisesForLesson(id: number) {
+    const result = await database.query(
+      `SELECT e.* FROM exercises e
+       JOIN lesson_exercises le ON le.exercise_id = e.id
+       WHERE le.lesson_id=$1
+       ORDER BY le.order_index`,
+      [id]
+    );
+    return result.rows;
+  }
+
+  private mapRow(row: any): Lesson {
+    return {
+      id: row.id,
+      title: row.title,
+      description: row.description,
+      createdAt: row.created_at,
+    };
+  }
+}
+
+export default new LessonService();

--- a/server/src/services/openai/openaiService.ts
+++ b/server/src/services/openai/openaiService.ts
@@ -141,6 +141,20 @@ class OpenAIService {
     }
   }
 
+  async chat(messages: { role: 'user' | 'assistant'; content: string }[]): Promise<string> {
+    try {
+      const response = await this.client.chat.completions.create({
+        model: 'gpt-4o-mini',
+        max_tokens: 512,
+        messages,
+      });
+      return response.choices[0].message.content || '';
+    } catch (error) {
+      logger.error('OpenAI API error:', error);
+      throw new Error('Failed to chat');
+    }
+  }
+
   private extractConcepts(text: string): string[] {
     const concepts: string[] = [];
     const conceptPatterns = [

--- a/server/src/types/lesson.ts
+++ b/server/src/types/lesson.ts
@@ -1,0 +1,6 @@
+export interface Lesson {
+  id: number;
+  title: string;
+  description: string | null;
+  createdAt: string;
+}

--- a/server/src/websocket/chatServer.ts
+++ b/server/src/websocket/chatServer.ts
@@ -1,0 +1,23 @@
+import { WebSocketServer } from 'ws';
+import { Server } from 'http';
+import OpenAIService from '../services/openai/openaiService';
+import { logger } from '../utils/logger';
+
+export function setupChatServer(server: Server) {
+  const wss = new WebSocketServer({ server, path: '/ws/chat' });
+
+  wss.on('connection', (ws) => {
+    ws.on('message', async (data) => {
+      const text = data.toString();
+      try {
+        const reply = await OpenAIService.chat([{ role: 'user', content: text }]);
+        ws.send(reply);
+      } catch (err) {
+        logger.error('Chat error', err);
+        ws.send('Error processing message');
+      }
+    });
+  });
+
+  logger.info('WebSocket chat server running');
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "commonjs",
     "lib": ["ES2022"],
+    "types": ["node"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Summary
- extend migration script to support migrations folder
- add lessons tables and service with API routes
- implement code execution endpoint
- integrate websocket-based AI chat
- expose lesson and exec services on frontend and update pages

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_6868459737c0832c9391947f52881e92